### PR TITLE
Update ubuntu base image and fix error with easyrsa version > 3.1.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04
+FROM ubuntu:24.10
 
 LABEL org.opencontainers.image.authors="s.rossovskii@gmail.com"
 

--- a/files/easyrsa/openssl-easyrsa.cnf
+++ b/files/easyrsa/openssl-easyrsa.cnf
@@ -1,6 +1,4 @@
-# For use with Easy-RSA 3.0 and OpenSSL 1.0.*
-
-RANDFILE		= $ENV::EASYRSA_PKI/.rnd
+# For use with Easy-RSA 3.0+ and OpenSSL or LibreSSL
 
 ####################################################################
 [ ca ]
@@ -15,23 +13,34 @@ crl_dir		= $dir			# Where the issued crl are kept
 database	= $dir/index.txt	# database index file.
 new_certs_dir	= $dir/certs_by_serial	# default place for new certs.
 
-certificate	= $dir/ca.crt	 	# The CA certificate
-serial		= $dir/serial 		# The current serial number
-crl		= $dir/crl.pem 		# The current CRL
+certificate	= $dir/ca.crt		# The CA certificate
+serial		= $dir/serial		# The current serial number
+crl		= $dir/crl.pem		# The current CRL
 private_key	= $dir/private/ca.key	# The private key
+RANDFILE	= $dir/.rand		# private random number file
 
-x509_extensions	= basic_exts		# The extentions to add to the cert
+x509_extensions	= basic_exts		# The extensions to add to the cert
+copy_extensions = copy
+
+# A placeholder to handle the --copy-ext feature:
+#%COPY_EXTS%	# Do NOT remove or change this line as --copy-ext support requires it
 
 # This allows a V2 CRL. Ancient browsers don't like it, but anything Easy-RSA
 # is designed for will. In return, we get the Issuer attached to CRLs.
 crl_extensions	= crl_ext
 
 default_days	= $ENV::EASYRSA_CERT_EXPIRE	# how long to certify for
-default_crl_days= $ENV::EASYRSA_CRL_DAYS	# how long before next CRL
+default_crl_days	= $ENV::EASYRSA_CRL_DAYS	# how long before next CRL
 default_md	= $ENV::EASYRSA_DIGEST		# use public key default MD
+
+# Note: preserve=no|yes, does nothing for EasyRSA.
+# Use sign-req command option 'preserve' instead.
 preserve	= no			# keep passed DN ordering
 
-# A few difference way of specifying how similar the request should look
+# This allows to renew certificates which have not been revoked
+unique_subject	= no
+
+# A few different ways of specifying how similar the request should look
 # For type CA, the listed attributes must be the same, and the optional
 # and supplied fields are just that :-)
 policy		= policy_anything
@@ -44,16 +53,18 @@ localityName		= optional
 organizationName	= optional
 organizationalUnitName	= optional
 commonName		= supplied
-name			= optional
 emailAddress		= optional
+serialNumber	= optional
 
-
+####################################################################
+# Easy-RSA request handling
+# We key off $DN_MODE to determine how to format the DN
 [ req ]
 default_bits		= $ENV::EASYRSA_KEY_SIZE
-default_keyfile 	= privkey.pem
+default_keyfile	= privkey.pem
 default_md		= $ENV::EASYRSA_DIGEST
 distinguished_name	= $ENV::EASYRSA_DN
-x509_extensions		= easyrsa_ca	# The extentions to add to the self signed cert
+x509_extensions		= easyrsa_ca	# The extensions to add to the self signed cert
 
 # A placeholder to handle the $EXTRA_EXTS feature:
 #%EXTRA_EXTS%	# Do NOT remove or change this line as $EXTRA_EXTS support requires it
@@ -94,6 +105,9 @@ emailAddress			= Email Address
 emailAddress_default		= $ENV::EASYRSA_REQ_EMAIL
 emailAddress_max		= 64
 
+serialNumber		= Serial-number (eg, device serial-number)
+serialNumber_default	= $ENV::EASYRSA_REQ_SERIAL
+
 ####################################################################
 # Easy-RSA cert extension handling
 
@@ -124,6 +138,9 @@ keyUsage = cRLSign, keyCertSign
 # nsCertType omitted by default. Let's try to let the deprecated stuff die.
 # nsCertType = sslCA
 
+# A placeholder to handle the $X509_TYPES and CA extra extensions $EXTRA_EXTS:
+#%CA_X509_TYPES_EXTRA_EXTS%	# Do NOT remove or change this line as $X509_TYPES and EXTRA_EXTS demands it
+
 # CRL extensions.
 [ crl_ext ]
 
@@ -131,4 +148,3 @@ keyUsage = cRLSign, keyCertSign
 
 # issuerAltName=issuer:copy
 authorityKeyIdentifier=keyid:always,issuer:always
-


### PR DESCRIPTION
Updated ubuntu base image and fixed issue which comes with new version of easyrsa when generating client certificates.